### PR TITLE
feat: add alert rules management

### DIFF
--- a/src/components/dashboard/AlertRuleDialog.tsx
+++ b/src/components/dashboard/AlertRuleDialog.tsx
@@ -1,0 +1,221 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { useAuth } from '@/hooks/useAuth';
+import { useToast } from '@/hooks/use-toast';
+import { supabase } from '@/integrations/supabase/client';
+
+interface Device {
+  id: string;
+  name: string;
+}
+
+interface AlertRule {
+  id: string;
+  device_id: string;
+  pin: string;
+  trigger_state: string;
+  message: string;
+  channel: string;
+}
+
+interface AlertRuleDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const AlertRuleDialog = ({ open, onOpenChange }: AlertRuleDialogProps) => {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [rules, setRules] = useState<AlertRule[]>([]);
+  const [deviceId, setDeviceId] = useState('');
+  const [pin, setPin] = useState('');
+  const [triggerState, setTriggerState] = useState('HIGH');
+  const [message, setMessage] = useState('');
+  const [channel, setChannel] = useState('email');
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open && user) {
+      loadDevices();
+      loadRules();
+    }
+  }, [open, user]);
+
+  const loadDevices = async () => {
+    if (!user) return;
+    const { data, error } = await supabase
+      .from('devices')
+      .select('id, name')
+      .eq('user_id', user.id)
+      .order('name');
+    if (!error) setDevices(data || []);
+  };
+
+  const loadRules = async () => {
+    if (!user) return;
+    const { data, error } = await supabase
+      .from('alert_rules')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: true });
+    if (!error) setRules(data || []);
+  };
+
+  const resetForm = () => {
+    setDeviceId('');
+    setPin('');
+    setTriggerState('HIGH');
+    setMessage('');
+    setChannel('email');
+    setEditingId(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+
+    const ruleData = {
+      user_id: user.id,
+      device_id: deviceId,
+      pin,
+      trigger_state: triggerState,
+      message,
+      channel,
+    };
+
+    try {
+      if (editingId) {
+        const { error } = await supabase
+          .from('alert_rules')
+          .update(ruleData)
+          .eq('id', editingId);
+        if (error) throw error;
+        toast({ title: 'Rule updated' });
+      } else {
+        const { error } = await supabase
+          .from('alert_rules')
+          .insert(ruleData);
+        if (error) throw error;
+        toast({ title: 'Rule added' });
+      }
+      resetForm();
+      loadRules();
+    } catch (error: any) {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    }
+  };
+
+  const handleEdit = (rule: AlertRule) => {
+    setDeviceId(rule.device_id);
+    setPin(rule.pin);
+    setTriggerState(rule.trigger_state);
+    setMessage(rule.message);
+    setChannel(rule.channel);
+    setEditingId(rule.id);
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      const { error } = await supabase
+        .from('alert_rules')
+        .delete()
+        .eq('id', id);
+      if (error) throw error;
+      toast({ title: 'Rule deleted' });
+      loadRules();
+    } catch (error: any) {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    }
+  };
+
+  const getDeviceName = (id: string) => devices.find(d => d.id === id)?.name || 'Unknown';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Alert Rules</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label>Device</Label>
+            <Select value={deviceId} onValueChange={setDeviceId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select device" />
+              </SelectTrigger>
+              <SelectContent>
+                {devices.map((d) => (
+                  <SelectItem key={d.id} value={d.id}>{d.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Pin or Address</Label>
+            <Input value={pin} onChange={(e) => setPin(e.target.value)} placeholder="e.g. D1 or S1" />
+          </div>
+          <div>
+            <Label>Trigger State</Label>
+            <Select value={triggerState} onValueChange={setTriggerState}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="HIGH">HIGH</SelectItem>
+                <SelectItem value="LOW">LOW</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Message</Label>
+            <Input value={message} onChange={(e) => setMessage(e.target.value)} />
+          </div>
+          <div>
+            <Label>Channel</Label>
+            <Select value={channel} onValueChange={setChannel}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="email">Email</SelectItem>
+                <SelectItem value="in-app">In App</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button type="submit">{editingId ? 'Update' : 'Add'} Rule</Button>
+          </DialogFooter>
+        </form>
+
+        <div className="mt-6">
+          <h3 className="font-semibold mb-2">Existing Rules</h3>
+          {rules.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No rules yet</p>
+          ) : (
+            <div className="space-y-2">
+              {rules.map((rule) => (
+                <div key={rule.id} className="border rounded p-3 flex items-start justify-between gap-2">
+                  <div>
+                    <p className="font-medium">{getDeviceName(rule.device_id)} - {rule.pin} {rule.trigger_state}</p>
+                    <p className="text-sm text-muted-foreground">{rule.message} ({rule.channel})</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => handleEdit(rule)}>Edit</Button>
+                    <Button size="sm" variant="destructive" onClick={() => handleDelete(rule.id)}>Delete</Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -4,6 +4,7 @@ import { DeviceList } from '../devices/DeviceList';
 import { DeviceView } from '../devices/DeviceView';
 import { BrokerSettingsDialog } from './BrokerSettingsDialog';
 import { NotificationsDialog } from './NotificationsDialog';
+import { AlertRuleDialog } from './AlertRuleDialog';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -21,6 +22,7 @@ export const Dashboard = () => {
   const [selectedDevice, setSelectedDevice] = useState<Device | null>(null);
   const [showBrokerSettings, setShowBrokerSettings] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
+  const [showAlertRules, setShowAlertRules] = useState(false);
   const [unreadAlerts, setUnreadAlerts] = useState(0);
 
   // Load unread alerts count
@@ -68,6 +70,7 @@ export const Dashboard = () => {
         onSettingsClick={() => setShowBrokerSettings(true)}
         onNotificationsClick={() => setShowNotifications(true)}
         unreadAlerts={unreadAlerts}
+        onAlertRulesClick={() => setShowAlertRules(true)}
       />
       
       <main>
@@ -90,6 +93,11 @@ export const Dashboard = () => {
         open={showNotifications}
         onOpenChange={setShowNotifications}
         onAlertsRead={loadUnreadAlerts}
+      />
+
+      <AlertRuleDialog
+        open={showAlertRules}
+        onOpenChange={setShowAlertRules}
       />
     </div>
   );

--- a/src/components/dashboard/Header.tsx
+++ b/src/components/dashboard/Header.tsx
@@ -1,4 +1,4 @@
-import { Bell, Settings, LogOut } from 'lucide-react';
+import { Bell, Settings, LogOut, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useMQTT } from '@/hooks/useMQTT';
@@ -14,9 +14,10 @@ interface HeaderProps {
   onSettingsClick: () => void;
   onNotificationsClick: () => void;
   unreadAlerts: number;
+  onAlertRulesClick: () => void;
 }
 
-export const Header = ({ onSettingsClick, onNotificationsClick, unreadAlerts }: HeaderProps) => {
+export const Header = ({ onSettingsClick, onNotificationsClick, unreadAlerts, onAlertRulesClick }: HeaderProps) => {
   const { status } = useMQTT();
   const { signOut } = useAuth();
 
@@ -47,7 +48,15 @@ export const Header = ({ onSettingsClick, onNotificationsClick, unreadAlerts }: 
           <Badge variant="secondary" className={`${getStatusColor()} text-white`}>
             MQTT: {getStatusText()}
           </Badge>
-          
+
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onAlertRulesClick}
+          >
+            <AlertTriangle className="h-5 w-5" />
+          </Button>
+
           <Button
             variant="ghost"
             size="icon"

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -62,6 +62,47 @@ export type Database = {
           },
         ]
       }
+      alert_rules: {
+        Row: {
+          id: string
+          user_id: string
+          device_id: string
+          pin: string
+          trigger_state: string
+          message: string
+          channel: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          device_id: string
+          pin: string
+          trigger_state: string
+          message: string
+          channel: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          device_id?: string
+          pin?: string
+          trigger_state?: string
+          message?: string
+          channel?: string
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "alert_rules_device_id_fkey"
+            columns: ["device_id"]
+            isOneToOne: false
+            referencedRelation: "devices"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       broker_settings: {
         Row: {
           created_at: string


### PR DESCRIPTION
## Summary
- add Supabase `alert_rules` type and CRUD dialog
- allow creating, editing and deleting device alert rules with channel and trigger state
- link new alert rule manager from dashboard header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c772d396e8832eb3be46cd5e497b83