### PR TITLE
feat: add alert widgets and firmware snippet support

### DIFF
--- a/src/components/devices/DeviceCard.tsx
+++ b/src/components/devices/DeviceCard.tsx
@@ -26,6 +26,7 @@ interface Device {
     switches: number;
     gauges: number;
     servos: number;
+    alerts: number;
   };
 }
 
@@ -60,6 +61,7 @@ export const DeviceCard = ({ device, onSelect, onDelete }: DeviceCardProps) => {
           <Badge variant="outline">Switches: {device.widget_counts?.switches || 0}</Badge>
           <Badge variant="outline">Gauges: {device.widget_counts?.gauges || 0}</Badge>
           <Badge variant="outline">Servos: {device.widget_counts?.servos || 0}</Badge>
+          <Badge variant="outline">Alerts: {device.widget_counts?.alerts || 0}</Badge>
         </div>
 
         <div className="flex gap-2">

--- a/src/components/devices/DeviceList.tsx
+++ b/src/components/devices/DeviceList.tsx
@@ -18,6 +18,7 @@ interface Device {
     switches: number;
     gauges: number;
     servos: number;
+    alerts: number;
   };
 }
 
@@ -53,6 +54,7 @@ export const DeviceList = ({ onDeviceSelect }: DeviceListProps) => {
           switches: device.widgets?.filter((w: any) => w.type === 'switch').length || 0,
           gauges: device.widgets?.filter((w: any) => w.type === 'gauge').length || 0,
           servos: device.widgets?.filter((w: any) => w.type === 'servo').length || 0,
+          alerts: device.widgets?.filter((w: any) => w.type === 'alert').length || 0,
         }
       }));
 

--- a/src/components/devices/DeviceView.tsx
+++ b/src/components/devices/DeviceView.tsx
@@ -8,6 +8,7 @@ import { useMQTT } from '@/hooks/useMQTT';
 import { SwitchWidget } from '../widgets/SwitchWidget';
 import { GaugeWidget } from '../widgets/GaugeWidget';
 import { ServoWidget } from '../widgets/ServoWidget';
+import { AlertWidget } from '../widgets/AlertWidget';
 import { AddWidgetDialog } from '../widgets/AddWidgetDialog';
 import { CodeSnippetDialog } from '../widgets/CodeSnippetDialog';
 
@@ -21,7 +22,7 @@ interface Device {
 
 interface Widget {
   id: string;
-  type: 'switch' | 'gauge' | 'servo';
+  type: 'switch' | 'gauge' | 'servo' | 'alert';
   label: string;
   address: string;
   pin?: number;
@@ -30,6 +31,8 @@ interface Widget {
   min_value?: number;
   max_value?: number;
   override_mode?: boolean;
+  trigger?: number;
+  message?: string;
   state: any;
 }
 
@@ -44,7 +47,7 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
   const [widgets, setWidgets] = useState<Widget[]>([]);
   const [loading, setLoading] = useState(true);
   const [showAddWidget, setShowAddWidget] = useState(false);
-  const [addWidgetType, setAddWidgetType] = useState<'switch' | 'gauge' | 'servo'>('switch');
+  const [addWidgetType, setAddWidgetType] = useState<'switch' | 'gauge' | 'servo' | 'alert'>('switch');
   const [showCodeSnippet, setShowCodeSnippet] = useState(false);
   const [deviceOnline, setDeviceOnline] = useState(device.online);
 
@@ -112,7 +115,7 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
     return cleanup;
   }, [device, onMessage]);
 
-  const handleAddWidget = (type: 'switch' | 'gauge' | 'servo') => {
+  const handleAddWidget = (type: 'switch' | 'gauge' | 'servo' | 'alert') => {
     setAddWidgetType(type);
     setShowAddWidget(true);
   };
@@ -171,6 +174,10 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
             <Plus className="mr-2 h-4 w-4" />
             Servo
           </Button>
+          <Button variant="outline" onClick={() => handleAddWidget('alert')}>
+            <Plus className="mr-2 h-4 w-4" />
+            Alert
+          </Button>
           <Button variant="outline" onClick={() => setShowCodeSnippet(true)}>
             <Code className="mr-2 h-4 w-4" />
             Code Snippet
@@ -193,6 +200,10 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
             <Button variant="outline" onClick={() => handleAddWidget('servo')}>
               <Plus className="mr-2 h-4 w-4" />
               Add Servo
+            </Button>
+            <Button variant="outline" onClick={() => handleAddWidget('alert')}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add Alert
             </Button>
           </div>
         </div>
@@ -225,6 +236,15 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
                   key={widget.id}
                   widget={widget}
                   device={device}
+                  onUpdate={(updates) => handleWidgetUpdated(widget.id, updates)}
+                  onDelete={() => handleWidgetDeleted(widget.id)}
+                />
+              );
+            } else if (widget.type === 'alert') {
+              return (
+                <AlertWidget
+                  key={widget.id}
+                  widget={widget}
                   onUpdate={(updates) => handleWidgetUpdated(widget.id, updates)}
                   onDelete={() => handleWidgetDeleted(widget.id)}
                 />

--- a/src/components/widgets/AlertWidget.tsx
+++ b/src/components/widgets/AlertWidget.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Settings, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+import { EditWidgetDialog } from './EditWidgetDialog';
+
+interface Widget {
+  id: string;
+  type: 'alert';
+  label: string;
+  address: string;
+  pin: number;
+  trigger: number;
+  message: string;
+  state?: any;
+}
+
+interface AlertWidgetProps {
+  widget: Widget;
+  onUpdate: (updates: Partial<Widget>) => void;
+  onDelete: () => void;
+}
+
+export const AlertWidget = ({ widget, onUpdate, onDelete }: AlertWidgetProps) => {
+  const { toast } = useToast();
+  const [showEdit, setShowEdit] = useState(false);
+
+  const handleDelete = async () => {
+    try {
+      const { error } = await supabase
+        .from('widgets')
+        .delete()
+        .eq('id', widget.id);
+
+      if (error) throw error;
+      onDelete();
+    } catch (error) {
+      console.error('Error deleting widget:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to delete widget',
+        variant: 'destructive'
+      });
+    }
+  };
+
+  return (
+    <Card className="bg-card border-border">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="font-semibold">{widget.label}</h3>
+            <p className="text-sm text-muted-foreground">
+              {widget.address} • GPIO {widget.pin} • {widget.trigger === 1 ? 'HIGH' : 'LOW'}
+            </p>
+          </div>
+          <div className="flex gap-1">
+            <Button variant="ghost" size="icon" onClick={() => setShowEdit(true)}>
+              <Settings className="h-4 w-4" />
+            </Button>
+            <Button variant="ghost" size="icon" onClick={handleDelete}>
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">
+        {widget.message}
+      </CardContent>
+      <EditWidgetDialog
+        open={showEdit}
+        onOpenChange={setShowEdit}
+        widget={widget}
+        onUpdate={onUpdate}
+      />
+    </Card>
+  );
+};

--- a/src/components/widgets/CodeSnippetDialog.tsx
+++ b/src/components/widgets/CodeSnippetDialog.tsx
@@ -22,8 +22,12 @@ export const CodeSnippetDialog = ({ open, onOpenChange, device, widgets }: CodeS
       `{ "${w.address}", GT_${w.gauge_type?.toUpperCase() || 'ANALOG'}, ${w.pin}, ${w.echo_pin || -1} }`
     ).join(',\n  ') || '// none';
     
-    const servos = widgets.filter(w => w.type === 'servo').map(w => 
+    const servos = widgets.filter(w => w.type === 'servo').map(w =>
       `{ "${w.address}", ${w.pin}, ${w.state?.angle || 90}, false }`
+    ).join(',\n  ') || '// none';
+
+    const alerts = widgets.filter(w => w.type === 'alert').map(w =>
+      `{ "${w.address}", ${w.pin}, ${w.trigger}, "${(w.message || '').replace(/"/g, '\\"')}" }`
     ).join(',\n  ') || '// none';
 
     return `// SapHari Device Configuration
@@ -42,7 +46,12 @@ GaugeMap GAUGES[] = {
 
 ServoMap SERVOS[] = {
   ${servos}
-};`;
+};
+
+AlertMap ALERTS[] = {
+  ${alerts}
+};
+int NUM_ALERTS = sizeof(ALERTS)/sizeof(ALERTS[0]);`;
   };
 
   return (

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -201,8 +201,10 @@ export type Database = {
           label: string
           max_value: number | null
           min_value: number | null
+          message: string | null
           override_mode: boolean | null
           pin: number | null
+          trigger: number | null
           state: Json | null
           type: string
           updated_at: string
@@ -217,8 +219,10 @@ export type Database = {
           label: string
           max_value?: number | null
           min_value?: number | null
+          message?: string | null
           override_mode?: boolean | null
           pin?: number | null
+          trigger?: number | null
           state?: Json | null
           type: string
           updated_at?: string
@@ -233,8 +237,10 @@ export type Database = {
           label?: string
           max_value?: number | null
           min_value?: number | null
+          message?: string | null
           override_mode?: boolean | null
           pin?: number | null
+          trigger?: number | null
           state?: Json | null
           type?: string
           updated_at?: string

--- a/supabase/migrations/20250914203032_add_alert_columns.sql
+++ b/supabase/migrations/20250914203032_add_alert_columns.sql
@@ -1,0 +1,3 @@
+-- Add alert widget support
+ALTER TABLE public.widgets ADD COLUMN "trigger" integer;
+ALTER TABLE public.widgets ADD COLUMN message text;


### PR DESCRIPTION
## Summary
- support new alert widgets with trigger condition and message fields
- expose alerts in device view, list, card and ESP32 snippet generator
- add database columns and migration for alert configuration

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c77a93a40c832e876d823a1d120ec2