### PR TITLE
feat: add login route and auth guard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,10 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Login from "./pages/Login";
 import NotFound from "./pages/NotFound";
+import { AuthProvider } from "@/hooks/useAuth";
+import { AuthGuard } from "@/components/auth/AuthGuard";
 
 const queryClient = new QueryClient();
 
@@ -13,15 +16,25 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
-);
+        <AuthProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/login" element={<Login />} />
+              <Route
+                path="/"
+                element={
+                  <AuthGuard>
+                    <Index />
+                  </AuthGuard>
+                }
+              />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </BrowserRouter>
+        </AuthProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
 
 export default App;

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@/hooks/useAuth';
-import { LoginForm } from './LoginForm';
+import { Navigate, useLocation } from 'react-router-dom';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -7,6 +7,7 @@ interface AuthGuardProps {
 
 export const AuthGuard = ({ children }: AuthGuardProps) => {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -20,7 +21,7 @@ export const AuthGuard = ({ children }: AuthGuardProps) => {
   }
 
   if (!user) {
-    return <LoginForm />;
+    return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
   return <>{children}</>;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,17 +1,11 @@
-import { AuthProvider } from '@/hooks/useAuth';
 import { MQTTProvider } from '@/hooks/useMQTT';
-import { AuthGuard } from '@/components/auth/AuthGuard';
 import { Dashboard } from '@/components/dashboard/Dashboard';
 
 const Index = () => {
   return (
-    <AuthProvider>
-      <AuthGuard>
-        <MQTTProvider>
-          <Dashboard />
-        </MQTTProvider>
-      </AuthGuard>
-    </AuthProvider>
+    <MQTTProvider>
+      <Dashboard />
+    </MQTTProvider>
   );
 };
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,18 @@
+import { LoginForm } from '@/components/auth/LoginForm';
+import { useAuth } from '@/hooks/useAuth';
+import { Navigate, useLocation, Location } from 'react-router-dom';
+
+const Login = () => {
+  const { user } = useAuth();
+  const location = useLocation();
+  const state = location.state as { from?: Location } | undefined;
+  const from = state?.from?.pathname || '/';
+
+  if (user) {
+    return <Navigate to={from} replace />;
+  }
+
+  return <LoginForm />;
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- add AuthProvider at app root and /login route
- redirect unauthorized users with AuthGuard
- provide dedicated Login page rendering LoginForm

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c77aded6dc832e89f6288f2dcb321a