### PR TITLE
feat: add login route and auth guard

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
   <title>SapHari MQTT Dashboard</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <script src="https://unpkg.com/mqtt/dist/mqtt.min.js"></script>
+  <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <script>
+    const supabaseUrl = "https://YOUR_PROJECT_ID.supabase.co";
+    const supabaseKey = "YOUR_ANON_KEY";
+    const supabase = supabase.createClient(supabaseUrl, supabaseKey);
+  </script>
   <style>
     body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;background:#0f1115;color:#eaeef2;margin:0}
     header{padding:16px 20px;border-bottom:1px solid #222;display:flex;justify-content:space-between;align-items:center}
@@ -38,7 +44,18 @@
     </div>
   </header>
 
-  <div class="wrap" id="deviceManager">
+  <div id="authView" class="wrap" style="display:none">
+    <h2>Login / Signup</h2>
+    <div class="row"><label>Email</label><input id="authEmail"></div>
+    <div class="row"><label>Password</label><input id="authPass" type="password"></div>
+    <div class="flex" style="gap:8px;margin-top:10px">
+      <button class="btn" onclick="doLogin()">Login</button>
+      <button class="btn secondary" onclick="doSignup()">Signup</button>
+    </div>
+    <div id="authMsg" class="small muted"></div>
+  </div>
+
+  <div class="wrap" id="deviceManager" style="display:none">
     <div class="flex between">
       <h2 style="margin:8px 0">Devices</h2>
       <button class="btn" onclick="openAddDevice()">➕ Add Device</button>
@@ -72,6 +89,40 @@ let devices = JSON.parse(localStorage.getItem('sh_devices')||'[]');
 // ensure new alerts array exists for older stored devices
 devices.forEach(d=>{ if(!d.widgets.alerts) d.widgets.alerts=[]; });
 let current = null;
+
+/* ========= Auth ========= */
+async function doSignup(){
+  const email = document.getElementById('authEmail').value;
+  const password = document.getElementById('authPass').value;
+  let { error } = await supabase.auth.signUp({ email, password });
+  if(error){ document.getElementById('authMsg').textContent = error.message; return; }
+  document.getElementById('authMsg').textContent = "Signup successful! Check your email to confirm.";
+}
+
+async function doLogin(){
+  const email = document.getElementById('authEmail').value;
+  const password = document.getElementById('authPass').value;
+  let { error } = await supabase.auth.signInWithPassword({ email, password });
+  if(error){ document.getElementById('authMsg').textContent = error.message; return; }
+  document.getElementById('authMsg').textContent = "Login successful!";
+  loadUserDashboard();
+}
+
+async function checkAuth(){
+  const { data: { session } } = await supabase.auth.getSession();
+  if(session){
+    loadUserDashboard();
+  } else {
+    document.getElementById('authView').style.display='block';
+  }
+}
+
+function loadUserDashboard(){
+  document.getElementById('authView').style.display='none';
+  document.getElementById('deviceManager').style.display='block';
+  renderDevices();
+  connectMQTT();
+}
 
 /* ========= MQTT Client ========= */
 let broker = JSON.parse(localStorage.getItem('sh_broker') || '{}');
@@ -823,8 +874,7 @@ int NUM_ALERTS = sizeof(ALERTS)/sizeof(ALERTS[0]);
 }
 
 /* ========= Boot ========= */
-renderDevices();
-connectMQTT();
+checkAuth();
 </script>
 </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,10 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Login from "./pages/Login";
 import NotFound from "./pages/NotFound";
+import { AuthProvider } from "@/hooks/useAuth";
+import { AuthGuard } from "@/components/auth/AuthGuard";
 
 const queryClient = new QueryClient();
 
@@ -13,15 +16,25 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
-);
+        <AuthProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/login" element={<Login />} />
+              <Route
+                path="/"
+                element={
+                  <AuthGuard>
+                    <Index />
+                  </AuthGuard>
+                }
+              />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </BrowserRouter>
+        </AuthProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
 
 export default App;

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@/hooks/useAuth';
-import { LoginForm } from './LoginForm';
+import { Navigate, useLocation } from 'react-router-dom';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -7,6 +7,7 @@ interface AuthGuardProps {
 
 export const AuthGuard = ({ children }: AuthGuardProps) => {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -20,7 +21,7 @@ export const AuthGuard = ({ children }: AuthGuardProps) => {
   }
 
   if (!user) {
-    return <LoginForm />;
+    return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
   return <>{children}</>;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,17 +1,11 @@
-import { AuthProvider } from '@/hooks/useAuth';
 import { MQTTProvider } from '@/hooks/useMQTT';
-import { AuthGuard } from '@/components/auth/AuthGuard';
 import { Dashboard } from '@/components/dashboard/Dashboard';
 
 const Index = () => {
   return (
-    <AuthProvider>
-      <AuthGuard>
-        <MQTTProvider>
-          <Dashboard />
-        </MQTTProvider>
-      </AuthGuard>
-    </AuthProvider>
+    <MQTTProvider>
+      <Dashboard />
+    </MQTTProvider>
   );
 };
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,18 @@
+import { LoginForm } from '@/components/auth/LoginForm';
+import { useAuth } from '@/hooks/useAuth';
+import { Navigate, useLocation, Location } from 'react-router-dom';
+
+const Login = () => {
+  const { user } = useAuth();
+  const location = useLocation();
+  const state = location.state as { from?: Location } | undefined;
+  const from = state?.from?.pathname || '/';
+
+  if (user) {
+    return <Navigate to={from} replace />;
+  }
+
+  return <LoginForm />;
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- add AuthProvider at app root and /login route
- redirect unauthorized users with AuthGuard
- provide dedicated Login page rendering LoginForm
- load Supabase client and expose login/signup flow that gates dashboard access

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*


------
https://chatgpt.com/codex/tasks/task_e_68c77aded6dc832e89f6288f2dcb321a