### PR TITLE
Allow alerts on any ESP32 pin

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@ const SWITCH_PINS=[2,4,5,12,13,14,15,16,17,18,19,21,22,23,25,26,27,32,33];
 const DIGITAL_PINS=[...SWITCH_PINS];
 const ANALOG_PINS =[32,33,34,35,36,39];
 const SERVO_PINS  =[...SWITCH_PINS];
+const ALERT_PINS  = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,21,22,23,25,26,27,32,33,34,35,36,37,38,39];
 
 function randId(){ return 'saph-' + Math.random().toString(36).slice(2,8); }
 function randKey(){ return Math.random().toString(36).slice(2,10).toUpperCase(); }
@@ -119,10 +120,10 @@ function usedPins(dev){
   dev.widgets.alerts.forEach(a=>u.add(a.pin));
   return u;
 }
-function pinOptions(allowed, dev, current){
+function pinOptions(allowed, dev, current, allowUsed=false){
   const used = usedPins(dev);
   return allowed.map(p=>{
-    const dis = used.has(p) && p!==current ? 'disabled' : '';
+    const dis = (!allowUsed && used.has(p) && p!==current) ? 'disabled' : '';
     const sel = p===current ? 'selected' : '';
     return `<option value="${p}" ${sel} ${dis}>${p}</option>`;
   }).join('');
@@ -523,7 +524,7 @@ function addAlert(){
       <div class="row"><label>Label</label><input id="alLbl" value="Alert"></div>
       <div class="row"><label>Address</label><input id="alAddr" value="${addr}" disabled></div>
       <div class="row"><label>GPIO Pin</label>
-        <select id="alPin">${pinOptions(DIGITAL_PINS, dev, null)}</select>
+        <select id="alPin">${pinOptions(ALERT_PINS, dev, null, true)}</select>
       </div>
       <div class="row"><label>Trigger</label>
         <select id="alTrig">

--- a/src/components/widgets/AddWidgetDialog.tsx
+++ b/src/components/widgets/AddWidgetDialog.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/hooks/use-toast';
 
 const SWITCH_PINS = [2,4,5,12,13,14,15,16,17,18,19,21,22,23,25,26,27,32,33];
 const ANALOG_PINS = [32,33,34,35,36,39];
+const ALL_PINS = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,21,22,23,25,26,27,32,33,34,35,36,37,38,39];
 
 interface AddWidgetDialogProps {
   open: boolean;
@@ -158,7 +159,7 @@ export const AddWidgetDialog = ({ open, onOpenChange, device, type, existingWidg
                     <SelectValue placeholder="Select pin" />
                   </SelectTrigger>
                   <SelectContent>
-                    {SWITCH_PINS.map(p => (
+                    {ALL_PINS.map(p => (
                       <SelectItem key={p} value={p.toString()}>{p}</SelectItem>
                     ))}
                   </SelectContent>


### PR DESCRIPTION
## Summary
- Enumerate full set of ESP32 GPIO pins and use for alert widgets so every valid pin can be selected
- Update legacy dashboard to expose the same comprehensive pin list for alerts and allow pin reuse

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 25 errors, 15 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68c821411578832e9be96f4229da3e6d