### PR TITLE
Add signup page and optional login form mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Login from "./pages/Login";
+import Signup from "./pages/Signup";
 import NotFound from "./pages/NotFound";
 import { AuthProvider } from "@/hooks/useAuth";
 import { AuthGuard } from "@/components/auth/AuthGuard";
@@ -20,6 +21,7 @@ const App = () => (
           <BrowserRouter>
             <Routes>
               <Route path="/login" element={<Login />} />
+              <Route path="/signup" element={<Signup />} />
               <Route
                 path="/"
                 element={

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -6,13 +7,22 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 
-export const LoginForm = () => {
+interface LoginFormProps {
+  initialMode?: 'login' | 'signup';
+}
+
+export const LoginForm = ({ initialMode = 'login' }: LoginFormProps) => {
   const { login, signup } = useAuth();
   const { toast } = useToast();
+  const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
-  const [isSignUp, setIsSignUp] = useState(false);
+  const [isSignUp, setIsSignUp] = useState(initialMode === 'signup');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    setIsSignUp(initialMode === 'signup');
+  }, [initialMode]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -84,7 +94,10 @@ export const LoginForm = () => {
           <div className="mt-4 text-center">
             <Button
               variant="link"
-              onClick={() => setIsSignUp(!isSignUp)}
+              onClick={() => {
+                if (isLoading) return;
+                navigate(isSignUp ? '/login' : '/signup');
+              }}
               disabled={isLoading}
             >
               {isSignUp ? 'Already have an account? Sign in' : "Don't have an account? Sign up"}

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,0 +1,18 @@
+import { LoginForm } from '@/components/auth/LoginForm';
+import { useAuth } from '@/hooks/useAuth';
+import { Navigate, useLocation, type Location } from 'react-router-dom';
+
+const Signup = () => {
+  const { user } = useAuth();
+  const location = useLocation();
+  const state = location.state as { from?: Location } | undefined;
+  const from = state?.from?.pathname || '/';
+
+  if (user) {
+    return <Navigate to={from} replace />;
+  }
+
+  return <LoginForm initialMode="signup" />;
+};
+
+export default Signup;


### PR DESCRIPTION
## Summary
- extend the shared LoginForm to accept an optional initialMode so it can render in signup mode
- add a dedicated Signup page and register the /signup route alongside the existing login route
- update the form navigation button to switch between the login and signup routes

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e109b030832ebe2420a1880231b8