### PR TITLE
Add shared auth loader and expose sign-out action

### DIFF
--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from '@/hooks/useAuth';
 import { Navigate, useLocation } from 'react-router-dom';
+import { FullPageLoader } from '@/components/ui/FullPageLoader';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -10,14 +11,7 @@ export const AuthGuard = ({ children }: AuthGuardProps) => {
   const location = useLocation();
 
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="text-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
-          <p className="mt-4 text-muted-foreground">Loading...</p>
-        </div>
-      </div>
-    );
+    return <FullPageLoader message="Checking session..." />;
   }
 
   if (!user) {

--- a/src/components/dashboard/Header.tsx
+++ b/src/components/dashboard/Header.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useMQTT } from '@/hooks/useMQTT';
 import { useAuth } from '@/hooks/useAuth';
+import { useNavigate } from 'react-router-dom';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,6 +21,16 @@ interface HeaderProps {
 export const Header = ({ onSettingsClick, onNotificationsClick, unreadAlerts, onAlertRulesClick }: HeaderProps) => {
   const { status } = useMQTT();
   const { signOut } = useAuth();
+  const navigate = useNavigate();
+
+  const handleSignOut = async () => {
+    try {
+      await signOut();
+      navigate('/login', { replace: true });
+    } catch (error) {
+      console.error('Sign out failed:', error);
+    }
+  };
 
   const getStatusColor = () => {
     switch (status) {
@@ -84,12 +95,13 @@ export const Header = ({ onSettingsClick, onNotificationsClick, unreadAlerts, on
               <DropdownMenuItem onClick={onSettingsClick}>
                 MQTT Settings
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={signOut}>
-                <LogOut className="mr-2 h-4 w-4" />
-                Sign Out
-              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+
+          <Button variant="outline" onClick={handleSignOut}>
+            <LogOut className="mr-2 h-4 w-4" />
+            Sign Out
+          </Button>
         </div>
       </div>
     </header>

--- a/src/components/ui/FullPageLoader.tsx
+++ b/src/components/ui/FullPageLoader.tsx
@@ -1,0 +1,12 @@
+interface FullPageLoaderProps {
+  message?: string;
+}
+
+export const FullPageLoader = ({ message = 'Loading...' }: FullPageLoaderProps) => (
+  <div className="flex min-h-screen items-center justify-center bg-background">
+    <div className="text-center">
+      <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+      <p className="mt-4 text-muted-foreground">{message}</p>
+    </div>
+  </div>
+);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,13 +1,15 @@
 import { LoginForm } from '@/components/auth/LoginForm';
 import { useAuth } from '@/hooks/useAuth';
-import { Navigate, useLocation, Location } from 'react-router-dom';
+import { Navigate, useLocation, type Location } from 'react-router-dom';
+import { FullPageLoader } from '@/components/ui/FullPageLoader';
 
 const Login = () => {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const location = useLocation();
   const state = location.state as { from?: Location } | undefined;
   const from = state?.from?.pathname || '/';
 
+  if (loading) return <FullPageLoader message="Checking session..." />;
   if (user) {
     return <Navigate to={from} replace />;
   }

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,13 +1,15 @@
 import { LoginForm } from '@/components/auth/LoginForm';
 import { useAuth } from '@/hooks/useAuth';
 import { Navigate, useLocation, type Location } from 'react-router-dom';
+import { FullPageLoader } from '@/components/ui/FullPageLoader';
 
 const Signup = () => {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const location = useLocation();
   const state = location.state as { from?: Location } | undefined;
   const from = state?.from?.pathname || '/';
 
+  if (loading) return <FullPageLoader message="Checking session..." />;
   if (user) {
     return <Navigate to={from} replace />;
   }


### PR DESCRIPTION
## Summary
- add a reusable full-page loader component and apply it to the auth guard plus the login and signup pages
- update the dashboard header to surface a sign-out button that redirects back to the login route

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c951e328e0832e99161d239816b424