### PR TITLE
Restore widget orchestration and persistence

### DIFF
--- a/src/components/widgets/AlertWidget.tsx
+++ b/src/components/widgets/AlertWidget.tsx
@@ -50,9 +50,25 @@ export const AlertWidget = ({ widget, onUpdate, onDelete }: AlertWidgetProps) =>
   };
 
   const handleAcknowledge = () => {
+    const updatedState = { ...widget.state, triggered: false };
     onUpdate({
-      state: { ...widget.state, triggered: false }
+      state: updatedState
     });
+
+    supabase
+      .from('widgets')
+      .update({ state: updatedState })
+      .eq('id', widget.id)
+      .then(({ error }) => {
+        if (error) {
+          console.error('Error acknowledging alert:', error);
+          toast({
+            title: "Error",
+            description: "Failed to acknowledge alert",
+            variant: "destructive"
+          });
+        }
+      });
   };
 
   return (

--- a/src/components/widgets/EditWidgetDialog.tsx
+++ b/src/components/widgets/EditWidgetDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -16,6 +16,10 @@ interface EditWidgetDialogProps {
 export const EditWidgetDialog = ({ open, onOpenChange, widget, onUpdate }: EditWidgetDialogProps) => {
   const { toast } = useToast();
   const [label, setLabel] = useState(widget.label);
+
+  useEffect(() => {
+    setLabel(widget.label);
+  }, [widget.label]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/widgets/ServoWidget.tsx
+++ b/src/components/widgets/ServoWidget.tsx
@@ -25,10 +25,11 @@ export const ServoWidget = ({ widget, device, onUpdate, onDelete }: ServoWidgetP
 
   const handleAngleChange = (value: number[]) => {
     const newAngle = value[0];
-    
+    const updatedState = { ...widget.state, angle: newAngle };
+
     // Update local state immediately
     onUpdate({
-      state: { ...widget.state, angle: newAngle }
+      state: updatedState
     });
 
     // Publish MQTT command
@@ -39,8 +40,23 @@ export const ServoWidget = ({ widget, device, onUpdate, onDelete }: ServoWidgetP
       angle: newAngle,
       key: device.device_key
     });
-    
+
     publishMessage(topic, payload);
+
+    supabase
+      .from('widgets')
+      .update({ state: updatedState })
+      .eq('id', widget.id)
+      .then(({ error }) => {
+        if (error) {
+          console.error('Error saving servo angle:', error);
+          toast({
+            title: "Error",
+            description: "Failed to persist servo angle",
+            variant: "destructive"
+          });
+        }
+      });
   };
 
   const handleEdit = () => {

--- a/src/components/widgets/SwitchWidget.tsx
+++ b/src/components/widgets/SwitchWidget.tsx
@@ -84,6 +84,8 @@ export const SwitchWidget = ({ widget, device, onUpdate, onDelete }: SwitchWidge
   };
 
   const handleDelete = async () => {
+    if (!confirm('Delete this switch widget?')) return;
+
     try {
       const { error } = await supabase
         .from('widgets')
@@ -92,6 +94,10 @@ export const SwitchWidget = ({ widget, device, onUpdate, onDelete }: SwitchWidge
 
       if (error) throw error;
       onDelete();
+      toast({
+        title: "Widget deleted",
+        description: "Switch widget has been removed"
+      });
     } catch (error) {
       console.error('Error deleting widget:', error);
       toast({


### PR DESCRIPTION
## Summary
- reset the widget creation dialog when reopened, enforce GPIO requirements, and seed gauge, servo, and alert payloads with sensible defaults for Supabase
- persist MQTT-driven state changes for widgets and mirror servo/alert acknowledgements back to Supabase so the dashboard stays in sync
- guard widget deletions with confirmation, refresh switch feedback, and harden ESP32 code generation with safe defaults and broker host fallback

## Testing
- npm run lint *(fails: repository already contains numerous legacy lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c95a04f4d4832eac91d9769f3eff3c