### PR TITLE
Enhance widget management and code generation

### DIFF
--- a/src/components/devices/DeviceView.tsx
+++ b/src/components/devices/DeviceView.tsx
@@ -81,7 +81,7 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
           const trimmed = message.trim();
           const numericValue = Number(trimmed);
           const isNumeric = !Number.isNaN(numericValue);
-          const nextState = { ...target.state };
+          const nextState = { ...(target.state ?? {}) };
 
           if (target.type === 'alert') {
             const triggered = trimmed === '1' || trimmed.toLowerCase() === 'true';
@@ -238,6 +238,7 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
                   key={widget.id}
                   widget={widget}
                   device={device}
+                  allWidgets={widgets}
                   onUpdate={(updates) => handleWidgetUpdated(widget.id, updates)}
                   onDelete={() => handleWidgetDeleted(widget.id)}
                 />
@@ -248,6 +249,7 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
                   key={widget.id}
                   widget={widget}
                   device={device}
+                  allWidgets={widgets}
                   onUpdate={(updates) => handleWidgetUpdated(widget.id, updates)}
                   onDelete={() => handleWidgetDeleted(widget.id)}
                 />
@@ -258,6 +260,7 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
                   key={widget.id}
                   widget={widget}
                   device={device}
+                  allWidgets={widgets}
                   onUpdate={(updates) => handleWidgetUpdated(widget.id, updates)}
                   onDelete={() => handleWidgetDeleted(widget.id)}
                 />
@@ -267,6 +270,7 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
                 <AlertWidget
                   key={widget.id}
                   widget={widget}
+                  allWidgets={widgets}
                   onUpdate={(updates) => handleWidgetUpdated(widget.id, updates)}
                   onDelete={() => handleWidgetDeleted(widget.id)}
                 />

--- a/src/components/widgets/AddWidgetDialog.tsx
+++ b/src/components/widgets/AddWidgetDialog.tsx
@@ -1,125 +1,232 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Switch as Toggle } from '@/components/ui/switch';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import { Device, Widget } from '@/lib/types';
 
-const SWITCH_PINS = [2,4,5,12,13,14,15,16,17,18,19,21,22,23,25,26,27,32,33];
-const ANALOG_PINS = [32,33,34,35,36,39];
-const ALL_PINS = Array.from({ length: 40 }, (_, i) => i);
+type GaugeType = 'analog' | 'pir' | 'ds18b20' | 'ultrasonic';
+type TriggerEdge = 'rising' | 'falling';
+
+const DIGITAL_PINS = [2, 4, 5, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33];
+const ANALOG_PINS = [32, 33, 34, 35, 36, 39];
+
+const GAUGE_DEFAULTS: Record<GaugeType, { min: number; max: number }> = {
+  analog: { min: 0, max: 4095 },
+  pir: { min: 0, max: 1 },
+  ds18b20: { min: -40, max: 125 },
+  ultrasonic: { min: 0, max: 400 },
+};
 
 interface AddWidgetDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  device: any;
+  device: Device;
   type: 'switch' | 'gauge' | 'servo' | 'alert';
-  existingWidgets: any[];
+  existingWidgets: Widget[];
   onWidgetAdded: () => void;
 }
 
-export const AddWidgetDialog = ({ open, onOpenChange, device, type, existingWidgets, onWidgetAdded }: AddWidgetDialogProps) => {
+const buildUsedPinSet = (widgets: Widget[]) => {
+  const used = new Set<number>();
+  widgets.forEach((widget) => {
+    if (widget.pin !== null && widget.pin !== undefined) {
+      used.add(widget.pin);
+    }
+    if (widget.echo_pin !== null && widget.echo_pin !== undefined) {
+      used.add(widget.echo_pin);
+    }
+  });
+  return used;
+};
+
+export const AddWidgetDialog = ({
+  open,
+  onOpenChange,
+  device,
+  type,
+  existingWidgets,
+  onWidgetAdded,
+}: AddWidgetDialogProps) => {
   const { toast } = useToast();
   const [label, setLabel] = useState('');
-  const [pin, setPin] = useState<number | undefined>();
-  const [gaugeType, setGaugeType] = useState('analog');
   const [overrideMode, setOverrideMode] = useState(false);
-  const [trigger, setTrigger] = useState('1');
+  const [gaugeType, setGaugeType] = useState<GaugeType>('analog');
+  const [pin, setPin] = useState<number | undefined>();
+  const [echoPin, setEchoPin] = useState<number | undefined>();
+  const [minValue, setMinValue] = useState<string>('0');
+  const [maxValue, setMaxValue] = useState<string>('0');
+  const [triggerEdge, setTriggerEdge] = useState<TriggerEdge>('rising');
   const [message, setMessage] = useState('');
+
+  const usedPins = useMemo(() => buildUsedPinSet(existingWidgets), [existingWidgets]);
 
   useEffect(() => {
     if (!open) return;
 
     setLabel('');
-    setPin(undefined);
-    setGaugeType('analog');
     setOverrideMode(false);
-    setTrigger('1');
+    setGaugeType('analog');
+    setPin(undefined);
+    setEchoPin(undefined);
+    const defaults = GAUGE_DEFAULTS['analog'];
+    setMinValue(String(defaults.min));
+    setMaxValue(String(defaults.max));
+    setTriggerEdge('rising');
     setMessage('');
   }, [open, type]);
 
   useEffect(() => {
     if (!open || type !== 'gauge') return;
+
+    const defaults = GAUGE_DEFAULTS[gaugeType];
+    setMinValue(String(defaults.min));
+    setMaxValue(String(defaults.max));
     setPin(undefined);
+    setEchoPin(undefined);
   }, [gaugeType, open, type]);
+
+  useEffect(() => {
+    if (!open || type !== 'switch') return;
+    if (overrideMode) {
+      setPin(undefined);
+    }
+  }, [overrideMode, open, type]);
+
+  const pinOptions = useMemo(() => {
+    if (type === 'alert') return [];
+
+    const sourcePins =
+      type === 'gauge'
+        ? gaugeType === 'analog'
+          ? ANALOG_PINS
+          : DIGITAL_PINS
+        : DIGITAL_PINS;
+
+    return sourcePins.map((gpio) => ({
+      value: gpio,
+      disabled: usedPins.has(gpio),
+    }));
+  }, [type, gaugeType, usedPins]);
+
+  const echoPinOptions = useMemo(() => {
+    if (type !== 'gauge' || gaugeType !== 'ultrasonic') return [];
+
+    return DIGITAL_PINS.map((gpio) => ({
+      value: gpio,
+      disabled: usedPins.has(gpio) || gpio === pin,
+    }));
+  }, [gaugeType, pin, type, usedPins]);
 
   const getNextAddress = () => {
     const prefix =
-      type === 'switch'
-        ? 'S'
-        : type === 'gauge'
-        ? 'G'
-        : type === 'servo'
-        ? 'SS'
-        : 'A';
-    const existing = existingWidgets.filter(w => w.type === type).map(w => w.address);
+      type === 'switch' ? 'S' : type === 'gauge' ? 'G' : type === 'servo' ? 'SS' : 'A';
+    const existing = existingWidgets.filter((w) => w.type === type).map((w) => w.address);
     let n = 1;
-    while (existing.includes(prefix + n)) n++;
-    return prefix + n;
+    while (existing.includes(`${prefix}${n}`)) n += 1;
+    return `${prefix}${n}`;
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
 
     try {
-      const pinRequired =
-        (type === 'switch' && !overrideMode) ||
-        type === 'gauge' ||
-        type === 'servo' ||
-        type === 'alert';
-
-      if (pinRequired && pin === undefined && type !== 'switch') {
-        toast({ title: "GPIO pin required", description: "Select a GPIO pin before creating the widget", variant: "destructive" });
-        return;
-      }
-
-      const widgetData: any = {
+      const widgetData: Record<string, unknown> = {
         device_id: device.id,
         type,
-        label: label || `${type} widget`,
+        label: label.trim() || `${type} widget`,
         address: getNextAddress(),
       };
 
       if (type === 'switch') {
         if (!overrideMode && pin === undefined) {
-          toast({ title: "GPIO pin required", description: "Select a GPIO pin for the switch", variant: "destructive" });
+          toast({
+            title: 'GPIO pin required',
+            description: 'Select a GPIO pin for the switch',
+            variant: 'destructive',
+          });
           return;
         }
-        widgetData.pin = overrideMode ? null : pin;
+
+        widgetData.pin = overrideMode ? null : pin ?? null;
         widgetData.override_mode = overrideMode;
         widgetData.state = { value: 0 };
       }
 
       if (type === 'gauge') {
-        widgetData.pin = pin;
-        widgetData.state = { value: 0 };
-        widgetData.gauge_type = gaugeType;
-
-        if (gaugeType === 'pir') {
-          widgetData.min_value = 0;
-          widgetData.max_value = 1;
-        } else if (gaugeType === 'ds18b20') {
-          widgetData.min_value = -40;
-          widgetData.max_value = 125;
-        } else if (gaugeType === 'ultrasonic') {
-          widgetData.min_value = 0;
-          widgetData.max_value = 400;
-        } else {
-          widgetData.min_value = 0;
-          widgetData.max_value = 4095;
+        if (pin === undefined) {
+          toast({
+            title: 'GPIO pin required',
+            description: 'Select a GPIO pin for the gauge sensor',
+            variant: 'destructive',
+          });
+          return;
         }
+
+        if (gaugeType === 'ultrasonic' && echoPin === undefined) {
+          toast({
+            title: 'Echo pin required',
+            description: 'Select an echo GPIO pin for the ultrasonic sensor',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        const min = parseFloat(minValue);
+        const max = parseFloat(maxValue);
+
+        if (Number.isNaN(min) || Number.isNaN(max)) {
+          toast({
+            title: 'Invalid range',
+            description: 'Enter valid numbers for min and max values',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        if (min >= max) {
+          toast({
+            title: 'Invalid range',
+            description: 'Min value must be less than max value',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        widgetData.pin = pin;
+        widgetData.echo_pin = gaugeType === 'ultrasonic' ? echoPin ?? null : null;
+        widgetData.gauge_type = gaugeType;
+        widgetData.min_value = min;
+        widgetData.max_value = max;
+        widgetData.state = { value: 0 };
       }
 
       if (type === 'servo') {
+        if (pin === undefined) {
+          toast({
+            title: 'GPIO pin required',
+            description: 'Select a GPIO pin for the servo',
+            variant: 'destructive',
+          });
+          return;
+        }
+
         widgetData.pin = pin;
         widgetData.state = { angle: 90 };
       }
 
       if (type === 'alert') {
-        widgetData.pin = pin;
-        widgetData.trigger = parseInt(trigger);
+        widgetData.trigger = triggerEdge === 'rising' ? 1 : 0;
         widgetData.message = message;
         widgetData.state = { triggered: false, lastTrigger: null };
       }
@@ -129,9 +236,10 @@ export const AddWidgetDialog = ({ open, onOpenChange, device, type, existingWidg
 
       onWidgetAdded();
       onOpenChange(false);
-      toast({ title: "Widget added successfully" });
-    } catch (error: any) {
-      toast({ title: "Error", description: error.message, variant: "destructive" });
+      toast({ title: 'Widget added successfully' });
+    } catch (error: unknown) {
+      const description = error instanceof Error ? error.message : 'Failed to add widget';
+      toast({ title: 'Error', description, variant: 'destructive' });
     }
   };
 
@@ -142,32 +250,30 @@ export const AddWidgetDialog = ({ open, onOpenChange, device, type, existingWidg
           <DialogTitle>Add {type} Widget</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
+          <div className="space-y-2">
             <Label>Label</Label>
-            <Input value={label} onChange={(e) => setLabel(e.target.value)} placeholder={`${type} widget`} />
+            <Input value={label} onChange={(event) => setLabel(event.target.value)} placeholder={`${type} widget`} />
           </div>
-          
+
           {type === 'switch' && (
-            <div>
+            <div className="space-y-2">
               <Label>Override Mode</Label>
-              <Select value={overrideMode ? 'true' : 'false'} onValueChange={(v) => setOverrideMode(v === 'true')}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select mode" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="false">Physical (requires GPIO)</SelectItem>
-                  <SelectItem value="true">Override only</SelectItem>
-                </SelectContent>
-              </Select>
+              <div className="flex items-center justify-between rounded-md border border-border p-3">
+                <div>
+                  <p className="text-sm font-medium">Use dashboard override only</p>
+                  <p className="text-xs text-muted-foreground">Disable GPIO control and only send software toggles.</p>
+                </div>
+                <Toggle checked={overrideMode} onCheckedChange={setOverrideMode} />
+              </div>
             </div>
           )}
 
           {type === 'gauge' && (
-            <div>
+            <div className="space-y-2">
               <Label>Sensor Type</Label>
-              <Select value={gaugeType} onValueChange={setGaugeType}>
+              <Select value={gaugeType} onValueChange={(value) => setGaugeType(value as GaugeType)}>
                 <SelectTrigger>
-                  <SelectValue />
+                  <SelectValue placeholder="Select sensor" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="analog">Analog</SelectItem>
@@ -179,57 +285,86 @@ export const AddWidgetDialog = ({ open, onOpenChange, device, type, existingWidg
             </div>
           )}
 
-          {(type !== 'switch' || !overrideMode) && type !== 'alert' ? (
-            <div>
-              <Label>GPIO Pin</Label>
-              <Select value={pin !== undefined ? String(pin) : undefined} onValueChange={(v) => setPin(parseInt(v))}>
+          {(type !== 'switch' || !overrideMode) && type !== 'alert' && (
+            <div className="space-y-2">
+              <Label>{type === 'gauge' && gaugeType === 'ultrasonic' ? 'Trig GPIO Pin' : 'GPIO Pin'}</Label>
+              <Select
+                value={pin !== undefined ? String(pin) : undefined}
+                onValueChange={(value) => setPin(parseInt(value, 10))}
+              >
                 <SelectTrigger>
                   <SelectValue placeholder="Select pin" />
                 </SelectTrigger>
                 <SelectContent>
-                  {(type === 'gauge' && gaugeType === 'analog' ? ANALOG_PINS : SWITCH_PINS).map(p => (
-                    <SelectItem key={p} value={p.toString()}>{p}</SelectItem>
+                  {pinOptions.map((option) => (
+                    <SelectItem key={option.value} value={String(option.value)} disabled={option.disabled}>
+                      GPIO {option.value}
+                    </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
-          ) : null}
-
-          {type === 'alert' && (
-            <>
-              <div>
-                <Label>GPIO Pin</Label>
-                <Select value={pin !== undefined ? String(pin) : undefined} onValueChange={(v) => setPin(parseInt(v))}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select pin" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {ALL_PINS.map(p => (
-                      <SelectItem key={p} value={p.toString()}>{p}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label>Trigger</Label>
-                <Select value={trigger} onValueChange={setTrigger}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="1">HIGH</SelectItem>
-                    <SelectItem value="0">LOW</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label>Message</Label>
-                <Input value={message} onChange={(e) => setMessage(e.target.value)} placeholder="Alert message" />
-              </div>
-            </>
           )}
 
-          <Button type="submit">Add Widget</Button>
+          {type === 'gauge' && gaugeType === 'ultrasonic' && (
+            <div className="space-y-2">
+              <Label>Echo GPIO Pin</Label>
+              <Select
+                value={echoPin !== undefined ? String(echoPin) : undefined}
+                onValueChange={(value) => setEchoPin(parseInt(value, 10))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select echo pin" />
+                </SelectTrigger>
+                <SelectContent>
+                  {echoPinOptions.map((option) => (
+                    <SelectItem key={option.value} value={String(option.value)} disabled={option.disabled}>
+                      GPIO {option.value}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {type === 'gauge' && (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Min Value</Label>
+                <Input type="number" value={minValue} onChange={(event) => setMinValue(event.target.value)} step="any" />
+              </div>
+              <div className="space-y-2">
+                <Label>Max Value</Label>
+                <Input type="number" value={maxValue} onChange={(event) => setMaxValue(event.target.value)} step="any" />
+              </div>
+            </div>
+          )}
+
+          {type === 'alert' && (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label>Trigger Edge</Label>
+                <Select value={triggerEdge} onValueChange={(value) => setTriggerEdge(value as TriggerEdge)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select trigger" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="rising">Rising</SelectItem>
+                    <SelectItem value="falling">Falling</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Message</Label>
+                <Input value={message} onChange={(event) => setMessage(event.target.value)} placeholder="Alert message" />
+              </div>
+            </div>
+          )}
+
+          <Button type="submit" className="w-full">
+            Add Widget
+          </Button>
         </form>
       </DialogContent>
     </Dialog>

--- a/src/components/widgets/AlertWidget.tsx
+++ b/src/components/widgets/AlertWidget.tsx
@@ -10,11 +10,12 @@ import { Widget } from '@/lib/types';
 
 interface AlertWidgetProps {
   widget: Widget;
+  allWidgets: Widget[];
   onUpdate: (updates: Partial<Widget>) => void;
   onDelete: () => void;
 }
 
-export const AlertWidget = ({ widget, onUpdate, onDelete }: AlertWidgetProps) => {
+export const AlertWidget = ({ widget, allWidgets, onUpdate, onDelete }: AlertWidgetProps) => {
   const { toast } = useToast();
   const [showEditDialog, setShowEditDialog] = useState(false);
 
@@ -40,17 +41,17 @@ export const AlertWidget = ({ widget, onUpdate, onDelete }: AlertWidgetProps) =>
         title: "Widget deleted",
         description: "Alert widget has been removed"
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         title: "Error",
-        description: error.message,
+        description: error instanceof Error ? error.message : 'Failed to delete widget',
         variant: "destructive"
       });
     }
   };
 
   const handleAcknowledge = () => {
-    const updatedState = { ...widget.state, triggered: false };
+    const updatedState = { ...(widget.state ?? {}), triggered: false };
     onUpdate({
       state: updatedState
     });
@@ -134,10 +135,10 @@ export const AlertWidget = ({ widget, onUpdate, onDelete }: AlertWidgetProps) =>
             
             <div className="text-xs text-iot-muted text-center space-x-2">
               <span>{widget.address}</span>
-              {widget.trigger && (
+              {widget.trigger !== null && widget.trigger !== undefined && (
                 <>
                   <span>•</span>
-                  <span>Trigger: {widget.trigger}</span>
+                  <span>Trigger: {widget.trigger === 0 ? 'Falling' : 'Rising'}</span>
                 </>
               )}
             </div>
@@ -149,6 +150,7 @@ export const AlertWidget = ({ widget, onUpdate, onDelete }: AlertWidgetProps) =>
         open={showEditDialog}
         onOpenChange={setShowEditDialog}
         widget={widget}
+        allWidgets={allWidgets}
         onUpdate={onUpdate}
       />
     </>

--- a/src/components/widgets/CodeSnippetDialog.tsx
+++ b/src/components/widgets/CodeSnippetDialog.tsx
@@ -2,13 +2,40 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { useMQTT } from '@/hooks/useMQTT';
+import { Device, Widget } from '@/lib/types';
 
 interface CodeSnippetDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  device: any;
-  widgets: any[];
+  device: Device;
+  widgets: Widget[];
 }
+
+const sanitizeMessage = (message: string) => message.replace(/"/g, '\\"');
+
+const getSwitchState = (widget: Widget) => {
+  const raw = widget.state?.['value'];
+  if (typeof raw === 'boolean') return raw;
+  if (typeof raw === 'number') return raw >= 0.5;
+  if (typeof raw === 'string') {
+    return raw === '1' || raw.toLowerCase() === 'true';
+  }
+  return false;
+};
+
+const getServoAngle = (widget: Widget) => {
+  const raw = widget.state?.['angle'];
+  if (typeof raw === 'number') return raw;
+  if (typeof raw === 'string') {
+    const parsed = Number(raw);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return 90;
+};
+
+const formatGaugeType = (type?: string | null) => `GT_${(type || 'analog').toUpperCase()}`;
 
 export const CodeSnippetDialog = ({ open, onOpenChange, device, widgets }: CodeSnippetDialogProps) => {
   const { brokerSettings } = useMQTT();
@@ -22,21 +49,31 @@ export const CodeSnippetDialog = ({ open, onOpenChange, device, widgets }: CodeS
   })();
 
   const generateCode = () => {
-    const switches = widgets.filter(w => w.type === 'switch').map(w =>
-      `{ "${w.address}", ${w.pin ?? -1}, false, ${w.override_mode ? 'true' : 'false'} }`
-    ).join(',\n  ') || '// none';
+    const switches = widgets
+      .filter((w) => w.type === 'switch')
+      .map((w) =>
+        `{ "${w.address}", ${w.pin ?? -1}, ${getSwitchState(w) ? 'true' : 'false'}, ${w.override_mode ? 'true' : 'false'} }`
+      )
+      .join(',\n  ');
 
-    const gauges = widgets.filter(w => w.type === 'gauge').map(w =>
-      `{ "${w.address}", GT_${(w.gauge_type?.toUpperCase() || 'ANALOG')}, ${w.pin ?? -1}, ${w.echo_pin ?? -1} }`
-    ).join(',\n  ') || '// none';
+    const gauges = widgets
+      .filter((w) => w.type === 'gauge')
+      .map((w) =>
+        `{ "${w.address}", ${formatGaugeType(w.gauge_type)}, ${w.pin ?? -1}, ${w.echo_pin ?? -1} }`
+      )
+      .join(',\n  ');
 
-    const servos = widgets.filter(w => w.type === 'servo').map(w =>
-      `{ "${w.address}", ${w.pin ?? -1}, ${w.state?.angle ?? 90}, false }`
-    ).join(',\n  ') || '// none';
+    const servos = widgets
+      .filter((w) => w.type === 'servo')
+      .map((w) => `{ "${w.address}", ${w.pin ?? -1}, ${getServoAngle(w)}, false }`)
+      .join(',\n  ');
 
-    const alerts = widgets.filter(w => w.type === 'alert').map(w =>
-      `{ "${w.address}", ${w.pin ?? -1}, ${w.trigger ?? 1}, "${(w.message || '').replace(/"/g, '\\"')}" }`
-    ).join(',\n  ') || '// none';
+    const alerts = widgets
+      .filter((w) => w.type === 'alert')
+      .map((w) =>
+        `{ "${w.address}", ${w.trigger ?? 1}, "${sanitizeMessage(w.message || '')}" }`
+      )
+      .join(',\n  ');
 
     return `// SapHari Device Configuration
 #define DEVICE_ID   "${device.device_id}"
@@ -45,19 +82,19 @@ export const CodeSnippetDialog = ({ open, onOpenChange, device, widgets }: CodeS
 #define MQTT_PORT   1883
 
 SwitchMap SWITCHES[] = {
-  ${switches}
+  ${switches || '// none'}
 };
 
 GaugeMap GAUGES[] = {
-  ${gauges}
+  ${gauges || '// none'}
 };
 
 ServoMap SERVOS[] = {
-  ${servos}
+  ${servos || '// none'}
 };
 
 AlertMap ALERTS[] = {
-  ${alerts}
+  ${alerts || '// none'}
 };
 int NUM_ALERTS = sizeof(ALERTS)/sizeof(ALERTS[0]);`;
   };

--- a/src/components/widgets/EditWidgetDialog.tsx
+++ b/src/components/widgets/EditWidgetDialog.tsx
@@ -1,42 +1,271 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Switch as Toggle } from '@/components/ui/switch';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import { Widget } from '@/lib/types';
+
+type GaugeType = 'analog' | 'pir' | 'ds18b20' | 'ultrasonic';
+type TriggerEdge = 'rising' | 'falling';
+
+const DIGITAL_PINS = [2, 4, 5, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 27, 32, 33];
+const ANALOG_PINS = [32, 33, 34, 35, 36, 39];
+
+const GAUGE_DEFAULTS: Record<GaugeType, { min: number; max: number }> = {
+  analog: { min: 0, max: 4095 },
+  pir: { min: 0, max: 1 },
+  ds18b20: { min: -40, max: 125 },
+  ultrasonic: { min: 0, max: 400 },
+};
 
 interface EditWidgetDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  widget: any;
-  onUpdate: (updates: any) => void;
+  widget: Widget;
+  allWidgets: Widget[];
+  onUpdate: (updates: Partial<Widget>) => void;
 }
 
-export const EditWidgetDialog = ({ open, onOpenChange, widget, onUpdate }: EditWidgetDialogProps) => {
+const buildUsedPinSet = (widgets: Widget[], currentWidgetId: string) => {
+  const used = new Set<number>();
+  widgets.forEach((item) => {
+    if (item.id === currentWidgetId) return;
+    if (item.pin !== null && item.pin !== undefined) {
+      used.add(item.pin);
+    }
+    if (item.echo_pin !== null && item.echo_pin !== undefined) {
+      used.add(item.echo_pin);
+    }
+  });
+  return used;
+};
+
+export const EditWidgetDialog = ({ open, onOpenChange, widget, allWidgets, onUpdate }: EditWidgetDialogProps) => {
   const { toast } = useToast();
   const [label, setLabel] = useState(widget.label);
+  const [overrideMode, setOverrideMode] = useState(Boolean(widget.override_mode));
+  const [gaugeType, setGaugeType] = useState<GaugeType>((widget.gauge_type as GaugeType) || 'analog');
+  const [pin, setPin] = useState<number | undefined>(widget.pin ?? undefined);
+  const [echoPin, setEchoPin] = useState<number | undefined>(widget.echo_pin ?? undefined);
+  const [minValue, setMinValue] = useState<string>(
+    widget.min_value !== null && widget.min_value !== undefined
+      ? String(widget.min_value)
+      : String(GAUGE_DEFAULTS[gaugeType].min)
+  );
+  const [maxValue, setMaxValue] = useState<string>(
+    widget.max_value !== null && widget.max_value !== undefined
+      ? String(widget.max_value)
+      : String(GAUGE_DEFAULTS[gaugeType].max)
+  );
+  const [triggerEdge, setTriggerEdge] = useState<TriggerEdge>(widget.trigger === 0 ? 'falling' : 'rising');
+  const [message, setMessage] = useState(widget.message || '');
+
+  const usedPins = useMemo(() => buildUsedPinSet(allWidgets, widget.id), [allWidgets, widget.id]);
+  const previousGaugeType = useRef<GaugeType | null>(null);
 
   useEffect(() => {
-    setLabel(widget.label);
-  }, [widget.label]);
+    if (!open) return;
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    
+    const initialGaugeType = (widget.gauge_type as GaugeType) || 'analog';
+    setLabel(widget.label);
+    setOverrideMode(Boolean(widget.override_mode));
+    setGaugeType(initialGaugeType);
+    setPin(widget.pin ?? undefined);
+    setEchoPin(widget.echo_pin ?? undefined);
+    setMinValue(
+      widget.min_value !== null && widget.min_value !== undefined
+        ? String(widget.min_value)
+        : String(GAUGE_DEFAULTS[initialGaugeType].min)
+    );
+    setMaxValue(
+      widget.max_value !== null && widget.max_value !== undefined
+        ? String(widget.max_value)
+        : String(GAUGE_DEFAULTS[initialGaugeType].max)
+    );
+    setTriggerEdge(widget.trigger === 0 ? 'falling' : 'rising');
+    setMessage(widget.message || '');
+    previousGaugeType.current = initialGaugeType;
+  }, [open, widget]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (widget.type === 'switch' && overrideMode) {
+      setPin(undefined);
+    }
+
+    if (widget.type === 'gauge') {
+      if (gaugeType === 'analog' && pin !== undefined && !ANALOG_PINS.includes(pin)) {
+        setPin(undefined);
+      }
+
+      if (gaugeType !== 'ultrasonic') {
+        setEchoPin(undefined);
+      }
+    }
+  }, [gaugeType, overrideMode, open, pin, widget.type]);
+
+  useEffect(() => {
+    if (!open || widget.type !== 'gauge') return;
+    if (previousGaugeType.current === null) {
+      previousGaugeType.current = gaugeType;
+      return;
+    }
+
+    if (previousGaugeType.current !== gaugeType) {
+      previousGaugeType.current = gaugeType;
+      const defaults = GAUGE_DEFAULTS[gaugeType];
+      setMinValue(String(defaults.min));
+      setMaxValue(String(defaults.max));
+    }
+  }, [gaugeType, open, widget.type]);
+
+  const pinOptions = useMemo(() => {
+    if (widget.type === 'alert') return [];
+
+    const allowedPins =
+      widget.type === 'gauge'
+        ? gaugeType === 'analog'
+          ? ANALOG_PINS
+          : DIGITAL_PINS
+        : DIGITAL_PINS;
+
+    return allowedPins.map((gpio) => ({
+      value: gpio,
+      disabled: usedPins.has(gpio) && gpio !== pin,
+    }));
+  }, [gaugeType, pin, usedPins, widget.type]);
+
+  const echoPinOptions = useMemo(() => {
+    if (widget.type !== 'gauge' || gaugeType !== 'ultrasonic') return [];
+
+    return DIGITAL_PINS.map((gpio) => ({
+      value: gpio,
+      disabled: (usedPins.has(gpio) && gpio !== echoPin) || gpio === pin,
+    }));
+  }, [echoPin, gaugeType, pin, usedPins, widget.type]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
     try {
-      const { error } = await supabase
-        .from('widgets')
-        .update({ label })
-        .eq('id', widget.id);
-      
+      const trimmedLabel = label.trim() || widget.label;
+      const updates: Record<string, unknown> = { label: trimmedLabel };
+      const localUpdates: Partial<Widget> = { label: trimmedLabel };
+
+      if (widget.type === 'switch') {
+        if (!overrideMode && pin === undefined) {
+          toast({
+            title: 'GPIO pin required',
+            description: 'Select a GPIO pin for the switch',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        updates.override_mode = overrideMode;
+        updates.pin = overrideMode ? null : pin ?? null;
+        localUpdates.override_mode = overrideMode;
+        localUpdates.pin = overrideMode ? null : pin ?? null;
+      }
+
+      if (widget.type === 'gauge') {
+        if (pin === undefined) {
+          toast({
+            title: 'GPIO pin required',
+            description: 'Select a GPIO pin for the gauge sensor',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        if (gaugeType === 'ultrasonic' && echoPin === undefined) {
+          toast({
+            title: 'Echo pin required',
+            description: 'Select an echo GPIO pin for the ultrasonic sensor',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        const min = parseFloat(minValue);
+        const max = parseFloat(maxValue);
+
+        if (Number.isNaN(min) || Number.isNaN(max)) {
+          toast({
+            title: 'Invalid range',
+            description: 'Enter valid numbers for min and max values',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        if (min >= max) {
+          toast({
+            title: 'Invalid range',
+            description: 'Min value must be less than max value',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        updates.pin = pin;
+        updates.echo_pin = gaugeType === 'ultrasonic' ? echoPin ?? null : null;
+        updates.gauge_type = gaugeType;
+        updates.min_value = min;
+        updates.max_value = max;
+
+        localUpdates.pin = pin;
+        localUpdates.echo_pin = gaugeType === 'ultrasonic' ? echoPin ?? null : null;
+        localUpdates.gauge_type = gaugeType;
+        localUpdates.min_value = min;
+        localUpdates.max_value = max;
+      }
+
+      if (widget.type === 'servo') {
+        if (pin === undefined) {
+          toast({
+            title: 'GPIO pin required',
+            description: 'Select a GPIO pin for the servo',
+            variant: 'destructive',
+          });
+          return;
+        }
+
+        updates.pin = pin;
+        localUpdates.pin = pin;
+      }
+
+      if (widget.type === 'alert') {
+        updates.trigger = triggerEdge === 'rising' ? 1 : 0;
+        updates.message = message;
+
+        localUpdates.trigger = triggerEdge === 'rising' ? 1 : 0;
+        localUpdates.message = message;
+      }
+
+      const { error } = await supabase.from('widgets').update(updates).eq('id', widget.id);
       if (error) throw error;
-      
-      onUpdate({ label });
+
+      onUpdate(localUpdates);
       onOpenChange(false);
-      toast({ title: "Widget updated" });
-    } catch (error: any) {
-      toast({ title: "Error", description: error.message, variant: "destructive" });
+      toast({ title: 'Widget updated' });
+    } catch (error: unknown) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to update widget',
+        variant: 'destructive',
+      });
     }
   };
 
@@ -47,11 +276,152 @@ export const EditWidgetDialog = ({ open, onOpenChange, widget, onUpdate }: EditW
           <DialogTitle>Edit Widget</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
+          <div className="space-y-2">
             <Label>Label</Label>
-            <Input value={label} onChange={(e) => setLabel(e.target.value)} />
+            <Input value={label} onChange={(event) => setLabel(event.target.value)} />
           </div>
-          <Button type="submit">Save</Button>
+
+          {widget.type === 'switch' && (
+            <div className="space-y-2">
+              <Label>Override Mode</Label>
+              <div className="flex items-center justify-between rounded-md border border-border p-3">
+                <div>
+                  <p className="text-sm font-medium">Use dashboard override only</p>
+                  <p className="text-xs text-muted-foreground">Disable GPIO control and only send software toggles.</p>
+                </div>
+                <Toggle checked={overrideMode} onCheckedChange={setOverrideMode} />
+              </div>
+            </div>
+          )}
+
+          {widget.type !== 'alert' && widget.type !== 'switch' && widget.type !== 'gauge' && (
+            <div className="space-y-2">
+              <Label>GPIO Pin</Label>
+              <Select value={pin !== undefined ? String(pin) : undefined} onValueChange={(value) => setPin(parseInt(value, 10))}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select pin" />
+                </SelectTrigger>
+                <SelectContent>
+                  {pinOptions.map((option) => (
+                    <SelectItem key={option.value} value={String(option.value)} disabled={option.disabled}>
+                      GPIO {option.value}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {widget.type === 'switch' && !overrideMode && (
+            <div className="space-y-2">
+              <Label>GPIO Pin</Label>
+              <Select value={pin !== undefined ? String(pin) : undefined} onValueChange={(value) => setPin(parseInt(value, 10))}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select pin" />
+                </SelectTrigger>
+                <SelectContent>
+                  {pinOptions.map((option) => (
+                    <SelectItem key={option.value} value={String(option.value)} disabled={option.disabled}>
+                      GPIO {option.value}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {widget.type === 'gauge' && (
+            <>
+              <div className="space-y-2">
+                <Label>Sensor Type</Label>
+                <Select value={gaugeType} onValueChange={(value) => setGaugeType(value as GaugeType)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select sensor" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="analog">Analog</SelectItem>
+                    <SelectItem value="pir">PIR</SelectItem>
+                    <SelectItem value="ds18b20">DS18B20</SelectItem>
+                    <SelectItem value="ultrasonic">Ultrasonic</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>{gaugeType === 'ultrasonic' ? 'Trig GPIO Pin' : 'GPIO Pin'}</Label>
+                <Select value={pin !== undefined ? String(pin) : undefined} onValueChange={(value) => setPin(parseInt(value, 10))}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select pin" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {pinOptions.map((option) => (
+                      <SelectItem key={option.value} value={String(option.value)} disabled={option.disabled}>
+                        GPIO {option.value}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {gaugeType === 'ultrasonic' && (
+                <div className="space-y-2">
+                  <Label>Echo GPIO Pin</Label>
+                  <Select
+                    value={echoPin !== undefined ? String(echoPin) : undefined}
+                    onValueChange={(value) => setEchoPin(parseInt(value, 10))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select echo pin" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {echoPinOptions.map((option) => (
+                        <SelectItem key={option.value} value={String(option.value)} disabled={option.disabled}>
+                          GPIO {option.value}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Min Value</Label>
+                  <Input type="number" value={minValue} onChange={(event) => setMinValue(event.target.value)} step="any" />
+                </div>
+                <div className="space-y-2">
+                  <Label>Max Value</Label>
+                  <Input type="number" value={maxValue} onChange={(event) => setMaxValue(event.target.value)} step="any" />
+                </div>
+              </div>
+            </>
+          )}
+
+          {widget.type === 'alert' && (
+            <>
+              <div className="space-y-2">
+                <Label>Trigger Edge</Label>
+                <Select value={triggerEdge} onValueChange={(value) => setTriggerEdge(value as TriggerEdge)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select trigger" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="rising">Rising</SelectItem>
+                    <SelectItem value="falling">Falling</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Message</Label>
+                <Input value={message} onChange={(event) => setMessage(event.target.value)} />
+              </div>
+            </>
+          )}
+
+          <Button type="submit" className="w-full">
+            Save
+          </Button>
         </form>
       </DialogContent>
     </Dialog>

--- a/src/components/widgets/ServoWidget.tsx
+++ b/src/components/widgets/ServoWidget.tsx
@@ -12,11 +12,12 @@ import { Widget, Device } from '@/lib/types';
 interface ServoWidgetProps {
   widget: Widget;
   device: Device;
+  allWidgets: Widget[];
   onUpdate: (updates: Partial<Widget>) => void;
   onDelete: () => void;
 }
 
-export const ServoWidget = ({ widget, device, onUpdate, onDelete }: ServoWidgetProps) => {
+export const ServoWidget = ({ widget, device, allWidgets, onUpdate, onDelete }: ServoWidgetProps) => {
   const { publishMessage } = useMQTT();
   const { toast } = useToast();
   const [showEditDialog, setShowEditDialog] = useState(false);
@@ -25,7 +26,7 @@ export const ServoWidget = ({ widget, device, onUpdate, onDelete }: ServoWidgetP
 
   const handleAngleChange = (value: number[]) => {
     const newAngle = value[0];
-    const updatedState = { ...widget.state, angle: newAngle };
+    const updatedState = { ...(widget.state ?? {}), angle: newAngle };
 
     // Update local state immediately
     onUpdate({
@@ -78,10 +79,10 @@ export const ServoWidget = ({ widget, device, onUpdate, onDelete }: ServoWidgetP
         title: "Widget deleted",
         description: "Servo widget has been removed"
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         title: "Error",
-        description: error.message,
+        description: error instanceof Error ? error.message : 'Failed to delete widget',
         variant: "destructive"
       });
     }
@@ -142,6 +143,7 @@ export const ServoWidget = ({ widget, device, onUpdate, onDelete }: ServoWidgetP
         open={showEditDialog}
         onOpenChange={setShowEditDialog}
         widget={widget}
+        allWidgets={allWidgets}
         onUpdate={onUpdate}
       />
     </>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,15 +18,15 @@ export interface Widget {
   type: 'switch' | 'gauge' | 'servo' | 'alert';
   label: string;
   address: string;
-  pin?: number;
-  echo_pin?: number;
-  gauge_type?: string;
-  min_value?: number;
-  max_value?: number;
-  override_mode?: boolean;
-  trigger?: number;
-  message?: string;
-  state: any;
+  pin?: number | null;
+  echo_pin?: number | null;
+  gauge_type?: 'analog' | 'pir' | 'ds18b20' | 'ultrasonic' | null;
+  min_value?: number | null;
+  max_value?: number | null;
+  override_mode?: boolean | null;
+  trigger?: number | null;
+  message?: string | null;
+  state: Record<string, unknown> | null;
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## Summary
- Expand the add widget dialog to reserve pins, handle sensor-specific fields (including ultrasonic echo pins and alert triggers), and validate ranges before inserting Supabase records
- Extend the edit widget dialog and dashboard widgets to share device-wide context, support updating pins/limits safely, and surface additional metadata while guarding local state updates
- Refresh the code snippet generator and widget typings so firmware exports include the new pin, echo, and trigger information with safer state typing

## Testing
- `npm run lint` *(fails: repository already contains pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9722794b0832ea8a15806f565b8f6