### PR TITLE
feat(alerts): allow configuring pin and level

### DIFF
--- a/src/components/devices/DeviceView.tsx
+++ b/src/components/devices/DeviceView.tsx
@@ -84,10 +84,28 @@ export const DeviceView = ({ device, onBack }: DeviceViewProps) => {
           const nextState = { ...(target.state ?? {}) };
 
           if (target.type === 'alert') {
-            const triggered = trimmed === '1' || trimmed.toLowerCase() === 'true';
+            const lowered = trimmed.toLowerCase();
+            let digitalValue: boolean | null = null;
+
+            if (!Number.isNaN(numericValue)) {
+              digitalValue = numericValue !== 0;
+            } else if (['true', 'high', 'on', '1'].includes(lowered)) {
+              digitalValue = true;
+            } else if (['false', 'low', 'off', '0'].includes(lowered)) {
+              digitalValue = false;
+            }
+
+            if (digitalValue === null) {
+              return prev;
+            }
+
+            const expectHigh = (target.trigger ?? 1) !== 0;
+            const triggered = expectHigh ? digitalValue : !digitalValue;
+
             if (triggered === Boolean(target.state?.triggered)) {
               return prev;
             }
+
             nextState.triggered = triggered;
             nextState.lastTrigger = triggered ? new Date().toISOString() : target.state?.lastTrigger;
           } else if (target.type === 'servo') {

--- a/src/components/widgets/AlertWidget.tsx
+++ b/src/components/widgets/AlertWidget.tsx
@@ -21,6 +21,9 @@ export const AlertWidget = ({ widget, allWidgets, onUpdate, onDelete }: AlertWid
 
   const isTriggered = widget.state?.triggered || false;
   const lastTrigger = widget.state?.lastTrigger;
+  const triggerLabel = widget.trigger === 0 ? 'Low' : 'High';
+  const pinLabel = widget.pin !== null && widget.pin !== undefined ? `GPIO ${widget.pin}` : null;
+  const metaItems = [widget.address, pinLabel, `Trigger: ${triggerLabel}`].filter(Boolean).map(String);
 
   const handleEdit = () => {
     setShowEditDialog(true);
@@ -133,15 +136,9 @@ export const AlertWidget = ({ widget, allWidgets, onUpdate, onDelete }: AlertWid
               </div>
             )}
             
-            <div className="text-xs text-iot-muted text-center space-x-2">
-              <span>{widget.address}</span>
-              {widget.trigger !== null && widget.trigger !== undefined && (
-                <>
-                  <span>•</span>
-                  <span>Trigger: {widget.trigger === 0 ? 'Falling' : 'Rising'}</span>
-                </>
-              )}
-            </div>
+            {metaItems.length > 0 && (
+              <div className="text-xs text-iot-muted text-center">{metaItems.join(' • ')}</div>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/components/widgets/CodeSnippetDialog.tsx
+++ b/src/components/widgets/CodeSnippetDialog.tsx
@@ -12,6 +12,7 @@ interface CodeSnippetDialogProps {
 }
 
 const sanitizeMessage = (message: string) => message.replace(/"/g, '\\"');
+const formatTriggerLevel = (trigger?: number | null) => ((trigger ?? 1) === 0 ? 'LOW' : 'HIGH');
 
 const getSwitchState = (widget: Widget) => {
   const raw = widget.state?.['value'];
@@ -71,7 +72,7 @@ export const CodeSnippetDialog = ({ open, onOpenChange, device, widgets }: CodeS
     const alerts = widgets
       .filter((w) => w.type === 'alert')
       .map((w) =>
-        `{ "${w.address}", ${w.trigger ?? 1}, "${sanitizeMessage(w.message || '')}" }`
+        `{ "${w.address}", ${w.pin ?? -1}, "${formatTriggerLevel(w.trigger)}", "${sanitizeMessage(w.message || '')}" }`
       )
       .join(',\n  ');
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -141,11 +141,13 @@ export type Database = {
           id: string
           label: string
           max_value: number | null
+          message: string | null
           min_value: number | null
           override_mode: boolean | null
           pin: number | null
           state: Json | null
           type: string
+          trigger: number | null
           updated_at: string
         }
         Insert: {
@@ -157,11 +159,13 @@ export type Database = {
           id?: string
           label: string
           max_value?: number | null
+          message?: string | null
           min_value?: number | null
           override_mode?: boolean | null
           pin?: number | null
           state?: Json | null
           type: string
+          trigger?: number | null
           updated_at?: string
         }
         Update: {
@@ -173,11 +177,13 @@ export type Database = {
           id?: string
           label?: string
           max_value?: number | null
+          message?: string | null
           min_value?: number | null
           override_mode?: boolean | null
           pin?: number | null
           state?: Json | null
           type?: string
+          trigger?: number | null
           updated_at?: string
         }
         Relationships: [

--- a/supabase/migrations/20250917000000_update_widgets_type_check.sql
+++ b/supabase/migrations/20250917000000_update_widgets_type_check.sql
@@ -1,0 +1,4 @@
+-- Allow alert widgets and keep existing constraint up to date
+ALTER TABLE public.widgets DROP CONSTRAINT IF EXISTS widgets_type_check;
+ALTER TABLE public.widgets
+  ADD CONSTRAINT widgets_type_check CHECK (type IN ('switch', 'gauge', 'servo', 'alert'));


### PR DESCRIPTION
## Summary
- allow choosing a GPIO pin and high/low trigger level when creating or editing alert widgets while keeping the UI in sync
- update the device runtime, alert card, and firmware snippet generator to respect the configured trigger level and surface the GPIO selection
- extend the Supabase schema/types so alert widgets are permitted and their trigger metadata is reflected in generated types

## Testing
- npm run lint *(fails: existing lint violations in untouched files)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19b200830832e82540ee351673aee