### PR TITLE
Allow alert widgets to use occupied GPIO pins

### DIFF
--- a/src/components/widgets/AddWidgetDialog.tsx
+++ b/src/components/widgets/AddWidgetDialog.tsx
@@ -111,9 +111,11 @@ export const AddWidgetDialog = ({
           : DIGITAL_PINS
         : DIGITAL_PINS;
 
+    const allowUsedPins = type === 'alert';
+
     return sourcePins.map((gpio) => ({
       value: gpio,
-      disabled: usedPins.has(gpio),
+      disabled: allowUsedPins ? false : usedPins.has(gpio),
     }));
   }, [type, gaugeType, usedPins]);
 

--- a/src/components/widgets/EditWidgetDialog.tsx
+++ b/src/components/widgets/EditWidgetDialog.tsx
@@ -138,9 +138,17 @@ export const EditWidgetDialog = ({ open, onOpenChange, widget, allWidgets, onUpd
           : DIGITAL_PINS
         : DIGITAL_PINS;
 
+    const shouldDisable = (gpio: number) => {
+      if (widget.type === 'alert') {
+        return false;
+      }
+
+      return usedPins.has(gpio) && gpio !== pin;
+    };
+
     return allowedPins.map((gpio) => ({
       value: gpio,
-      disabled: usedPins.has(gpio) && gpio !== pin,
+      disabled: shouldDisable(gpio),
     }));
   }, [gaugeType, pin, usedPins, widget.type]);
 


### PR DESCRIPTION
## Summary
- stop disabling GPIO options for alert widgets in the add widget dialog
- allow selecting any GPIO pin for alerts when editing an existing widget

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a6961a4c832e9d3d257a2f4eb412